### PR TITLE
getAsXhtml did not merge parser and visitor errors.

### DIFF
--- a/src/document/rst.php
+++ b/src/document/rst.php
@@ -359,6 +359,13 @@ class ezcDocumentRst extends ezcDocument implements ezcDocumentXhtmlConversion, 
             $visitor->visit( $this->ast, $this->path )
         );
 
+        // Merge errors from converter
+        $this->errors = array_merge(
+            $this->errors,
+            $parser->getErrors(),
+            $visitor->getErrors()
+        );
+
         return $document;
     }
 


### PR DESCRIPTION
Whenever the errorReporting option only included `E_PARSE & E_ERROR`
it was impossible to get the errors generated by the visitor and parser 
as these were not propagated. This commit changes that by merging the
parser and visitor errors into this error listing.

This is a replica of the behaviour in the getAsDocbook() method.
