### PR TITLE
Roles in the RST XHTML visitor did not have their SourceVisitor set

### DIFF
--- a/src/document/rst/visitor/xhtml.php
+++ b/src/document/rst/visitor/xhtml.php
@@ -467,6 +467,7 @@ class ezcDocumentRstXhtmlVisitor extends ezcDocumentRstVisitor
                 null, $node->token->line, $node->token->position
             );
         }
+        $roleHandler->setSourceVisitor($this);
         $roleHandler->toXhtml( $this->document, $root );
     }
 


### PR DESCRIPTION
In my project I use the visitor to retrieve objects that are shared between roles and directives. Directives have their setSourceVisitor() method called to store the calling visitor on the directive; Roles also have a setSourceVisitor() method but this is not called during the visit. This commit changes that.
