### PR TITLE
clone is not a function, but a keyword, and so do not need calling paren...

### DIFF
--- a/src/document/rst/parser.php
+++ b/src/document/rst/parser.php
@@ -3057,7 +3057,7 @@ class ezcDocumentRstParser extends ezcDocumentParser
                 /* DEBUG
                 echo "Split, ";
                 // /DEBUG */
-                $newToken = clone( $token );
+                $newToken = clone $token;
                 $token->content = substr( $token->content, 0, $split );
 
                 $newToken->content = substr( $newToken->content, $split + 1 );


### PR DESCRIPTION
...thesis