### PR TITLE
PHP 7.2 deprecation fix

### DIFF
--- a/tests/pcss/parser_test.php
+++ b/tests/pcss/parser_test.php
@@ -145,7 +145,7 @@ class ezcDocumentPcssParserTests extends ezcTestCase
         {
             $this->assertSame(
                 $message,
-                preg_replace( '(in file \'[^\']+\')', 'in file \'$file\'', $e->getMessage() ),
+                preg_replace( '/(in file \'[^\']+\')/', 'in file \'$file\'', $e->getMessage() ),
                 'Different parse error expected.'
             );
         }


### PR DESCRIPTION
Fixes:

```
 PHP | File:Line                                                                                          |             Type | Issue
 5.5 | /tests/pcss/parser_test.php:148                                                                    | function_usage   | Function usage preg_replace() (@preg_replace_e_modifier) is deprecated. 
```